### PR TITLE
teamを作成できる

### DIFF
--- a/backend/src/app/team/post-team-usecase.ts
+++ b/backend/src/app/team/post-team-usecase.ts
@@ -1,0 +1,17 @@
+import { Team } from 'src/domain/entity/team'
+import { ITeamRepository } from './repository-interface/team-repository'
+
+export class PostTeamUseCase {
+  private readonly teamRepo: ITeamRepository
+  public constructor(teamRepo: ITeamRepository) {
+    this.teamRepo = teamRepo
+  }
+  public async do(params: { name: string }) {
+    const { name } = params
+
+    const someDataEntity = new Team({
+      name,
+    })
+    await this.teamRepo.save(someDataEntity)
+  }
+}

--- a/backend/src/app/team/repository-interface/team-repository.ts
+++ b/backend/src/app/team/repository-interface/team-repository.ts
@@ -1,0 +1,5 @@
+import { Team } from 'src/domain/entity/team'
+
+export interface ITeamRepository {
+  save(team: Team): Promise<Team>
+}

--- a/backend/src/controller/team/request/post-team-request.ts
+++ b/backend/src/controller/team/request/post-team-request.ts
@@ -1,0 +1,11 @@
+// @see https://docs.nestjs.com/openapi/types-and-parameters
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, IsString } from 'class-validator'
+
+export class PostTeamRequest {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  readonly name!: string
+}

--- a/backend/src/controller/team/teams.controller.ts
+++ b/backend/src/controller/team/teams.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get } from '@nestjs/common'
+import { Body, Controller, Get, Post } from '@nestjs/common'
 import { GetTeamResponse } from './response/get-team-response'
+import { PostTeamRequest } from './request/post-team-request'
 import { GetTeamUseCase } from '../../app/team/get-team-usecase'
+import { PostTeamUseCase } from '../../app/team/post-team-usecase'
+import { TeamRepository } from 'src/infra/db/repository/team/team-repository'
 import { PrismaClient } from '@prisma/client'
 import { TeamQS } from 'src/infra/db/query-service/team-qs'
 
@@ -16,5 +19,15 @@ export class TeamsController {
     const result = await usecase.do()
     const response = new GetTeamResponse({ teams: result })
     return response
+  }
+
+  @Post()
+  async postTeam(@Body() postTeamDTO: PostTeamRequest): Promise<void> {
+    const prisma = new PrismaClient()
+    const repo = new TeamRepository(prisma)
+    const usecase = new PostTeamUseCase(repo)
+    await usecase.do({
+      name: postTeamDTO.name,
+    })
   }
 }

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -1,0 +1,13 @@
+export class Team {
+  private name: string
+  public constructor(props: { name: string }) {
+    const { name } = props
+    this.name = name
+  }
+
+  public getAllProperties() {
+    return {
+      name: this.name,
+    }
+  }
+}

--- a/backend/src/infra/db/repository/team/team-repository.ts
+++ b/backend/src/infra/db/repository/team/team-repository.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from '@prisma/client'
+import { ITeamRepository } from 'src/app/team/repository-interface/team-repository'
+import { Team } from 'src/domain/entity/team'
+
+export class TeamRepository implements ITeamRepository {
+  private prismaClient: PrismaClient
+  public constructor(prismaClient: PrismaClient) {
+    this.prismaClient = prismaClient
+  }
+
+  public async save(teamEntity: Team): Promise<Team> {
+    const { name } = teamEntity.getAllProperties()
+
+    const savedTeamDatamodel = await this.prismaClient.team.create({
+      data: {
+        name,
+      },
+    })
+    const savedTeamEntity = new Team({
+      ...savedTeamDatamodel,
+    })
+    return savedTeamEntity
+  }
+}


### PR DESCRIPTION
ユニーク制約違反の場合に、クライアントに返すエラー
```
{
    "statusCode": 500,
    "message": "Internal server error"
}
```

サーバのログ
```
Error: 
Invalid `prisma.team.create()` invocation:


  Unique constraint failed on the fields: (`name`)
```